### PR TITLE
Added cache to store results for one day

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,6 +4,7 @@ all: index.js
 
 clean:
 	rm -rf index.js
+	coffee clean.coffee
 
 index.js: index.coffee
 	coffee -c $^

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ You may pass an object in between the address and the callback function to tweak
     "cache": true,   // cache results for 24 hours (default)
 	"follow":  2,    // number of times to follow redirects
 	"timeout": 0,    // socket timeout, excluding this doesn't override any default timeout value
-	"verbose": false // setting this to true returns an array of responses from all servers,
+	"verbose": false // setting this to true returns an array of responses from all servers
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ You may pass an object in between the address and the callback function to tweak
 ```js
 {
 	"server":  "",   // this can be a string ("host:port") or an object with host and port as its keys; leaving it empty makes lookup rely on servers.json
-    "cache": true,   // cache results for 24 hours (default)
+	"cache": true,   // cache results for 24 hours (default)
 	"follow":  2,    // number of times to follow redirects
 	"timeout": 0,    // socket timeout, excluding this doesn't override any default timeout value
 	"verbose": false // setting this to true returns an array of responses from all servers

--- a/README.md
+++ b/README.md
@@ -22,9 +22,10 @@ You may pass an object in between the address and the callback function to tweak
 ```js
 {
 	"server":  "",   // this can be a string ("host:port") or an object with host and port as its keys; leaving it empty makes lookup rely on servers.json
+    "cache": true,   // cache results for 24 hours (default)
 	"follow":  2,    // number of times to follow redirects
 	"timeout": 0,    // socket timeout, excluding this doesn't override any default timeout value
-	"verbose": false // setting this to true returns an array of responses from all servers
+	"verbose": false // setting this to true returns an array of responses from all servers,
 }
 ```
 

--- a/clean.coffee
+++ b/clean.coffee
@@ -1,0 +1,11 @@
+_ = require 'underscore'
+fs = require 'fs'
+os = require 'os'
+
+# clean cache by deleting files
+# in the temp folder with the "node-whois-" prefix
+
+files = fs.readdirSync os.tmpdir()
+_.each files, (file) ->
+	if file.match(/^node-whois-/)
+		fs.unlinkSync os.tmpdir() + file

--- a/clean.coffee
+++ b/clean.coffee
@@ -8,4 +8,4 @@ os = require 'os'
 files = fs.readdirSync os.tmpdir()
 _.each files, (file) ->
 	if file.match(/^node-whois-/)
-		fs.unlinkSync os.tmpdir() + file
+		fs.unlinkSync os.tmpdir() + "/" + file

--- a/index.coffee
+++ b/index.coffee
@@ -110,7 +110,7 @@ os = require 'os'
 						done null, parts
 				return
 
-		if cache
+		if cache and data.match(new RegExp(addr, "i"))
 			data = data.replace(/\r\n|\r|\n/g, os.EOL)
 			now = (new Date()).toISOString()
 			data = ">>> Last update of client data cache: #{now} <<<#{os.EOL}#{data}"

--- a/index.coffee
+++ b/index.coffee
@@ -70,6 +70,8 @@ os = require 'os'
 					encoding: "utf-8"
 				, done
 				return
+			else
+				fs.unlink cache
 
 	socket = net.connect server.port, server.host, =>
 		idn = addr

--- a/index.coffee
+++ b/index.coffee
@@ -61,7 +61,7 @@ crypto = require 'crypto'
 
 	if cache
 		if typeof cache != 'string'
-			cache = os.tmpdir() + "node-whois-" + crypto
+			cache = os.tmpdir() + "/node-whois-" + crypto
 			.createHash('md5')
 			.update(addr + JSON.stringify(
 				_.omit(options, 'cache', 'timeout')

--- a/index.coffee
+++ b/index.coffee
@@ -4,6 +4,7 @@ punycode = require 'punycode'
 util = require 'util'
 fs = require 'fs'
 os = require 'os'
+crypto = require 'crypto'
 
 
 @SERVERS = require './servers.json'
@@ -60,7 +61,12 @@ os = require 'os'
 
 	if cache
 		if typeof cache != 'string'
-			cache = os.tmpdir() + "node-whois-" + addr
+			cache = os.tmpdir() + "node-whois-" + crypto
+			.createHash('md5')
+			.update(addr + JSON.stringify(
+				_.omit(options, 'cache', 'timeout')
+			))
+			.digest('hex')
 
 		if fs.existsSync(cache)
 			stats = fs.statSync(cache)
@@ -115,7 +121,7 @@ os = require 'os'
 		if cache and data.match(new RegExp(addr, "i"))
 			data = data.replace(/\r\n|\r|\n/g, os.EOL)
 			now = (new Date()).toISOString()
-			data = ">>> Last update of client data cache: #{now} <<<#{os.EOL}#{data}"
+			data = ">>> Last update of client data cache: #{now} <<<#{os.EOL}>>> lookup options #{JSON.stringify(_.omit(options, 'cache', 'timeout'))} <<<#{os.EOL}#{data}"
 			fs.writeFile cache, data
 
 		if options.verbose

--- a/test.coffee
+++ b/test.coffee
@@ -10,6 +10,22 @@ describe '#lookup()', ->
 			assert.notEqual data.toLowerCase().indexOf('domain name: google.com'), -1
 			done()
 
+	it 'should work with ename.com without cache', (done) ->
+		whois.lookup 'ename.com', cache: false, server: 'whois.ename.com', (err, data) ->
+			assert.ifError err
+			data = data.toLowerCase()
+			assert.equal data.indexOf('client data cache: '), -1
+			assert.notEqual data.indexOf('domain name: ename.com'), -1
+			done()
+
+	it 'should work with ename.com with cache', (done) ->
+		whois.lookup 'ename.com', cache: true, server: 'whois.ename.com', (err, data) ->
+			assert.ifError err
+			data = data.toLowerCase()
+			assert.notEqual data.indexOf('client data cache: '), -1
+			assert.notEqual data.indexOf('domain name: ename.com'), -1
+			done()
+
 	it 'should work with 50.116.8.109', (done) ->
 		whois.lookup '50.116.8.109', (err, data) ->
 			assert.ifError err

--- a/test.coffee
+++ b/test.coffee
@@ -26,6 +26,15 @@ describe '#lookup()', ->
 			assert.notEqual data.indexOf('domain name: ename.com'), -1
 			done()
 
+	it 'should cache different results with different options', (done) ->
+		whois.lookup 'ename.com', cache: true, server: 'whois.easyspace.com', follow: 0, (err, data) ->
+			assert.ifError err
+			data = data.toLowerCase()
+			assert.notEqual data.indexOf('whois.easyspace.com'), -1
+			assert.notEqual data.indexOf('client data cache: '), -1
+			assert.notEqual data.indexOf('domain name: ename.com'), -1
+			done()
+
 	it 'should work with 50.116.8.109', (done) ->
 		whois.lookup '50.116.8.109', (err, data) ->
 			assert.ifError err


### PR DESCRIPTION
I use node-whois as part of our automated tests, so I routinely hit request limits on WHOIS servers. The response data is generally considered good for 24 hours, so I added a simple cache using local file storage. I added two tests and one option to allow disabling the cache. I tried to write this code to be cross-platform, but I have only tested on Mac OS X and Linux.
