### PR TITLE
Show full records for multiple hits on ARIN

### DIFF
--- a/servers.json
+++ b/servers.json
@@ -670,7 +670,7 @@
   "_": {
     "ipv4": {
       "host": "whois.arin.net",
-      "query": "n $addr\r\n"
+      "query": "n + $addr\r\n"
     }
   }
 }


### PR DESCRIPTION
The plus flag shows full records for IP addresses which have multiple hits on ARIN, for example 173.8.0.0, while without the plus you get a useless listing of matches but not the full data.
