### PR TITLE
Added  correct utf-8 support for whois.norid.no

### DIFF
--- a/servers.json
+++ b/servers.json
@@ -529,7 +529,10 @@
   "ng": "whois.nic.net.ng",
   "ni": null,
   "nl": "whois.domain-registry.nl",
-  "no": "whois.norid.no",
+  "no": {
+    "host": "whois.norid.no",
+    "query": "-c utf-8 $addr\r\n"
+  },
   "np": null,
   "nr": null,
   "nu": "whois.iis.nu",


### PR DESCRIPTION
To create support for unicode characters in both domains and meta information.

To test: query=åre.no