### PR TITLE
Fix for WHOIS server parsing error on follow

### DIFF
--- a/index.coffee
+++ b/index.coffee
@@ -18,7 +18,7 @@ util = require 'util'
 
 	done = _.once done
 
-	server = options.server
+	server = options.server and options.server.trim()
 	proxy = options.proxy
 	timeout = options.timeout
 


### PR DESCRIPTION
Added trim() to options.server, to handle cases where server is parsed with whitespace and returns DNS error.
i.e. "whois.name.com :43" instead of "whois.name.com:43"

To reproduce the issue I addresses please test the following:
`node index.js --follow 3 cuizeene.com`