### PR TITLE
Using whois.nic.cloud  for cloud

### DIFF
--- a/servers.json
+++ b/servers.json
@@ -108,7 +108,7 @@
   "cleaning": "whois.nic.cleaning",
   "clinic": "whois.nic.clinic",
   "clothing": "whois.nic.clothing",
-  "cloud": "whois.namecheap.com",
+  "cloud": "whois.nic.cloud",
   "club": "whois.nic.club",
   "codes": "whois.nic.codes",
   "coffee": "whois.nic.coffee",


### PR DESCRIPTION
After some digging and based on https://www.iana.org/domains/root/db/cloud.html it is much better to use the original whois server whois.nic.cloud instead of the namecheap one.