### PR TITLE
Removed duplicated whois server for .name TLD

### DIFF
--- a/servers.json
+++ b/servers.json
@@ -282,7 +282,6 @@
   "motorcycles": "whois.nic.motorcycles",
   "movie": "whois.nic.movie",
   "nagoya": "whois.nic.nagoya",
-  "name": "whois.namecheap.com",  
   "navy": "whois.nic.navy",  
   "network": "whois.nic.network",
   "neustar": "whois.nic.neustar",


### PR DESCRIPTION
In servers.json WHOIS server for ".name" is duplicated.
The original and correct one is there 
https://github.com/FurqanSoftware/node-whois/blob/master/servers.json#L57
And based on https://www.iana.org/domains/root/db/name.html it is better to use the original whois server whois.nic.name