### PR TITLE
Update .au

### DIFF
--- a/servers.json
+++ b/servers.json
@@ -463,7 +463,7 @@
   "as": "whois.nic.as",
   "priv.at": "whois.nic.priv.at",
   "at": "whois.nic.at",
-  "au": "whois.audns.net.au",
+  "au": "whois.auda.org.au",
   "aw": "whois.nic.aw",
   "ax": "whois.ax",
   "az": null,


### PR DESCRIPTION
Both still work, but this seems to be the currently supported address. Others probably still exist in DNS for legacy purposes.

https://www.auda.org.au/index.php/industry-information/au-domains/whois/
https://forums.whirlpool.net.au/thread/9r7vy2w3?p=8#r56889128