### PR TITLE
Fix url+port parsing error

### DIFF
--- a/index.coffee
+++ b/index.coffee
@@ -8,8 +8,7 @@ util = require 'util'
 @SERVERS = require './servers.json'
 
 cleanParsingErrors = (string) =>
-	cleanPattern = /[:\s]+/gm
-	return string.replace(cleanPattern, '') || string
+	return string.replace(/^[:\s]+/, '') || string
 
 @lookup = (addr, options, done) =>
 	if typeof done is 'undefined' and typeof options is 'function'


### PR DESCRIPTION
After the #86 was applied, all `colon` in redirect-url are removed.
Thus, url `rwhois.sonic.net:4321` replace to `rwhois.sonic.net4321`, it causes #89.
This PR would fix the errors which are reported in #86 and #89.
