### PR TITLE
Change WHOIS server for .in TLD

### DIFF
--- a/servers.json
+++ b/servers.json
@@ -566,7 +566,7 @@
   "ie": "whois.domainregistry.ie",
   "il": "whois.isoc.org.il",
   "im": "whois.nic.im",
-  "in": "whois.inregistry.net",
+  "in": "whois.registry.in",
   "io": "whois.nic.io",
   "iq": "whois.cmc.iq",
   "ir": "whois.nic.ir",


### PR DESCRIPTION
Change WHOIS server for `.it` TLD in accordance to https://www.iana.org/domains/root/db/in.html