### PR TITLE
Update servers.json

### DIFF
--- a/servers.json
+++ b/servers.json
@@ -442,7 +442,7 @@
   "xn--unup4y": "whois.nic.xn--unup4y",
   "xn--vhquv": "whois.nic.xn--vhquv",
   "xn--zfr164b": "whois.nic.xn--zfr164b",
-  "xyz": "whois.nic.xyz",
+  "xyz": "whois.namecheap.com",
   "yachts": "whois.nic.yachts",
   "yokohama": "whois.nic.yokohama",
   "zone": "whois.nic.zone",


### PR DESCRIPTION
changed whois.nic.xyz to whois.namecheap.com for xyz zone:
whois.namecheap.com is more reliable than whois.nic.xyz for xyz zone: whois.nic.xyz often gives permanent timeout