### PR TITLE
fix(vulnerability): Prototype Pollution Vulnerability

### DIFF
--- a/index.coffee
+++ b/index.coffee
@@ -15,7 +15,7 @@ cleanParsingErrors = (string) =>
 		done = options
 		options = {}
 		
-        if addr == '__proto__'
+      if addr == '__proto__'
               done new Error 'lookup: __proto__ is not allowed to lookup'
 		return
 

--- a/index.coffee
+++ b/index.coffee
@@ -14,6 +14,10 @@ cleanParsingErrors = (string) =>
 	if typeof done is 'undefined' and typeof options is 'function'
 		done = options
 		options = {}
+		
+        if addr == '__proto__'
+                done new Error 'lookup: __proto__ is not allowed to lookup'
+		return
 
 	_.defaults options,
 		follow: 2

--- a/index.coffee
+++ b/index.coffee
@@ -16,7 +16,7 @@ cleanParsingErrors = (string) =>
 		options = {}
 		
         if addr == '__proto__'
-                done new Error 'lookup: __proto__ is not allowed to lookup'
+              done new Error 'lookup: __proto__ is not allowed to lookup'
 		return
 
 	_.defaults options,


### PR DESCRIPTION
Screenshot proving that injection has occurred:
![image](https://user-images.githubusercontent.com/51540538/102945707-4bf78900-449d-11eb-8e55-1aed28c07db0.png)
Note that port 43 in error and port in prototype are same

This pull request is to prevent tentatives of prototype pollution

## How to reproduce:
```js
whois.lookup("__proto__", (err, data) => console.log(data))
const obj = {}
console.log(obj.__proto__)
// [Object: null prototype] { port: 43, query: '$addr\r\n' }
```