### PR TITLE
RFC1034 character match

### DIFF
--- a/bin.coffee
+++ b/bin.coffee
@@ -1,5 +1,6 @@
 yargs = require 'yargs'
 whois = require './index'
+util = require 'util'
 
 yargs.usage('$0 [options] address')
 .default('s', null)
@@ -31,7 +32,7 @@ if not yargs.argv._[0]?
     yargs.showHelp()
     process.exit 1
 
-@lookup yargs.argv._[0], server: yargs.argv.server, follow: yargs.argv.follow, proxy: yargs.argv.proxy, verbose: yargs.argv.verbose, bind: yargs.argv.bind, (err, data) =>
+whois.lookup yargs.argv._[0], server: yargs.argv.server, follow: yargs.argv.follow, proxy: yargs.argv.proxy, verbose: yargs.argv.verbose, bind: yargs.argv.bind, (err, data) =>
     if err?
         console.log err
         process.exit 1

--- a/index.coffee
+++ b/index.coffee
@@ -92,7 +92,7 @@ cleanParsingErrors = (string) =>
 
 		socket.on 'close', (err) =>
 			if options.follow > 0
-				match = data.replace(/\r/gm, '').match /(ReferralServer|Registrar Whois|Whois Server|WHOIS Server|Registrar WHOIS Server):[^\S\n]*((?:r?whois|https?):\/\/)?(.*)/
+				match = data.replace(/\r/gm, '').match /(ReferralServer|Registrar Whois|Whois Server|WHOIS Server|Registrar WHOIS Server|refer):[^\S\n]*((?:r?whois|https?):\/\/)?([0-9A-Za-z\.\-_]*)/
 				if match? and match[3] != server.host
 					options = _.extend {}, options,
 						follow: options.follow - 1

--- a/servers.json
+++ b/servers.json
@@ -782,7 +782,7 @@
   "xn--yfro4i67o": "whois.sgnic.sg",
   "xn--ygbi2ammx": "whois.pnina.ps",
 
-  "": "whois.ripe.net",
+  "": "whois.iana.org",
 
   "_": {
     "ip": {

--- a/test.coffee
+++ b/test.coffee
@@ -52,26 +52,26 @@ describe '#lookup()', ->
 	it 'should work with verbose option', (done) ->
 		whois.lookup 'google.com', {verbose: true}, (err, data) ->
 			assert.ifError err
-			assert.equal data[0].server, 'whois.verisign-grs.com'
+			assert.equal (data[0].server == 'whois.verisign-grs.com') or (data[0].server == 'whois.markmonitor.com'), 1
 			assert.notEqual data[0].data.toLowerCase().indexOf('domain name: google.com'), -1
 			done()
 
 	it 'should work with nic.sh', (done) ->
 		whois.lookup 'nic.sh', (err, data) ->
 			assert.ifError err
-			assert.notEqual data.toLowerCase().indexOf('registry domain id: d503300000040403495-lrms'), -1
+			assert.notEqual data.toLowerCase().indexOf('registry domain id: dede5cd207a640ae8285d181431a00c4-donuts'), -1
 			done()
 
 	it 'should work with nic.io', (done) ->
 		whois.lookup 'nic.io', (err, data) ->
 			assert.ifError err
-			assert.notEqual data.toLowerCase().indexOf('registry domain id: d503300000040453277-lrms'), -1
+			assert.notEqual data.toLowerCase().indexOf('registry domain id: 09b2461d0b6449ffbc9edb53bc7326c1-donuts'), -1
 			done()
 
 	it 'should work with nic.ac', (done) ->
 		whois.lookup 'nic.ac', (err, data) ->
 			assert.ifError err
-			assert.notEqual data.toLowerCase().indexOf('registry domain id: d503300000040632620-lrms'), -1
+			assert.notEqual data.toLowerCase().indexOf('registry domain id: bcb94de2bd4e43459a9ef5e67e2e02d3-donuts'), -1
 			done()
 
 	it 'should work with nic.tm', (done) ->
@@ -83,13 +83,13 @@ describe '#lookup()', ->
 	it 'should work with nic.global', (done) ->
 		whois.lookup 'nic.global', (err, data) ->
 			assert.ifError err
-			assert.notEqual data.toLowerCase().indexOf('registry domain id: d2836144-agrs'), -1
+			assert.notEqual data.toLowerCase().indexOf('registry domain id: 696c235291444e9ab8c0f1336238c349-donuts'), -1
 			done()
 
 	it 'should work with srs.net.nz', (done) ->
 		whois.lookup 'srs.net.nz', (err, data) ->
 			assert.ifError err
-			assert.notEqual data.toLowerCase().indexOf('domain_name: srs.net.nz'), -1
+			assert.notEqual data.toLowerCase().indexOf('domain name: srs.net.nz'), -1
 			done()
 
 	it 'should work with redundant follow', (done) ->
@@ -112,9 +112,9 @@ describe '#lookup()', ->
 			done()
 
 	it 'should work with registry.pro', (done) ->
-		whois.lookup 'registry.pro', (err, data) ->
+		whois.lookup 'registry.pro', follow: 0, (err, data) ->
 			assert.ifError err
-			assert.notEqual data.toLowerCase().indexOf('domain id: d107300000000006392-lrms'), -1
+			assert.notEqual data.toLowerCase().indexOf('domain id: a78bed915c9748fdbdf91224299d2058-donuts'), -1
 			done()
 
 	it 'should fail with google.com due to timeout', (done) ->
@@ -156,7 +156,7 @@ describe '#lookup()', ->
 	it 'should work with 148.241.109.161', (done) ->
 		whois.lookup '148.241.109.161', {encoding: 'binary'}, (err, data) ->
 			assert.ifError err
-			assert.notEqual data.indexOf('Instituto Tecnológico'), -1
+			assert.notEqual data.indexOf('MX-ITYE8-LACNIC'), -1
 			done()
 
 	it 'should work with dot.ai', (done) ->


### PR DESCRIPTION
Change for server regex to only match on RFC1034 valid characters (plus underscore). Fixes #114 .

Also includes changes required to make test suite succeed, fix the binary, and changes the default server for an unknown TLD from RIPE NCC to IANA.