### PR TITLE
Fix .tr WHOIS server: whois.nic.tr no longer resolves

### DIFF
--- a/servers.json
+++ b/servers.json
@@ -695,7 +695,7 @@
   "tn": "whois.ati.tn",
   "to": "whois.tonic.to",
   "tp": null,
-  "tr": "whois.nic.tr",
+  "tr": "whois.trabis.gov.tr",
   "tt": null,
   "tv": "tvwhois.verisign-grs.com",
   "tw": "whois.twnic.net.tw",


### PR DESCRIPTION
The current `tr` entry points at `whois.nic.tr`, which no longer resolves — so WHOIS lookups for every `.tr` domain fail:

```
$ whois -h whois.nic.tr google.com.tr
whois: whois.nic.tr: nodename nor servname provided, or not known
```

`.tr` is administered by Trabis (under BTK), whose authoritative WHOIS server is `whois.trabis.gov.tr` on TCP/43. It answers the default `<domain>\r\n` query, so no custom `query` format is needed:

```
$ whois -h whois.trabis.gov.tr google.com.tr
** Domain Name: google.com.tr
Domain Status: Active
...
** Registrar:
Organization Name : ODTÜ GELİŞTİRME VAKFI BİLGİ TEKNOLOJİLERİ SAN. VE TİC. A.Ş.
...
```

This one-line change restores WHOIS for all `.tr` domains (`com.tr`, `net.tr`, `gen.tr`, `gov.tr`, …), since they share the `tr` registry server.